### PR TITLE
Added row alter for base entity tables plugin

### DIFF
--- a/src/BaseEntityTablesInterface.php
+++ b/src/BaseEntityTablesInterface.php
@@ -27,4 +27,16 @@ interface BaseEntityTablesInterface extends PluginInspectionInterface {
    */
   public function alterRowTemplate(array &$row_template, array $entity_state_info);
 
+  /**
+   * Alter row data.
+   *
+   * @param array $row
+   *   Reference to row.
+   * @param string $table_name
+   *   The table name of the row.
+   * @param \Drupal\testsite_builder\ContentCreatorStorage $content_creator_storage
+   *   The content creator storage.
+   */
+  public function alterRow(array &$row, $table_name, ContentCreatorStorage $content_creator_storage);
+
 }

--- a/src/ContentCreator.php
+++ b/src/ContentCreator.php
@@ -325,7 +325,6 @@ class ContentCreator {
       'parent_id' => $parent_id,
       'parent_type' => $parent_type,
       'parent_field_name' => $parent_field_name,
-      'content_creator_storage' => $this->storage,
     ];
 
     $this->entityTypeReferenceNestingStack[$unique_bundle_key] = $entity_type_state;
@@ -338,10 +337,12 @@ class ContentCreator {
 
     $column_mapping = $this->config[$entity_type]['_entity_definition_keys'];
 
+    // Get entity tables plugin.
+    $entity_tables_plugin = $this->getBaseEntityTablesPlugin($entity_type);
+
     // Prepare row arrays.
     $row_templates = $this->getBaseTableTemplates($entity_type);
-    $this->getBaseEntityTablesPlugin($entity_type)
-      ->alterRowTemplate($row_templates, $entity_type_state);
+    $entity_tables_plugin->alterRowTemplate($row_templates, $entity_type_state);
     $variable_row_data = [
       'bundle' => $bundle_type,
     ];
@@ -362,6 +363,9 @@ class ContentCreator {
             continue;
           }
         }
+
+        // Alter variable part of row.
+        $entity_tables_plugin->alterRow($row, $table_name, $this->storage);
 
         fputcsv($this->cacheCsvFileHandlers[$entity_type][$table_name], array_values($row));
       }

--- a/src/ContentCreatorStorage.php
+++ b/src/ContentCreatorStorage.php
@@ -143,4 +143,23 @@ class ContentCreatorStorage {
     return $this->sampleDataStorage[$type][rand(0, count($this->sampleDataStorage[$type]) - 1)];
   }
 
+  /**
+   * Get sample data used to generate database entries with mod of provided ID.
+   *
+   * @param string $type
+   *   The data type.
+   * @param int $id
+   *   The ID of entry we are fetching sample data for.
+   *
+   * @return mixed
+   *   Returns sample data.
+   */
+  public function getModSampleDataType($type, $id) {
+    if (!isset($this->sampleDataStorage[$type])) {
+      return [];
+    }
+
+    return $this->sampleDataStorage[$type][$id % count($this->sampleDataStorage[$type])];
+  }
+
 }

--- a/src/Plugin/TestsiteBuilder/BaseEntityTables/Generic.php
+++ b/src/Plugin/TestsiteBuilder/BaseEntityTables/Generic.php
@@ -3,6 +3,7 @@
 namespace Drupal\testsite_builder\Plugin\TestsiteBuilder\BaseEntityTables;
 
 use Drupal\testsite_builder\BaseEntityTablesBase;
+use Drupal\testsite_builder\ContentCreatorStorage;
 
 /**
  * Generic entity type plugin.
@@ -48,5 +49,10 @@ class Generic extends BaseEntityTablesBase {
    * {@inheritdoc}
    */
   public function alterRowTemplate(array &$row_template, array $entity_state_info) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRow(array &$row, $table_name, ContentCreatorStorage $content_creator_storage) {}
 
 }

--- a/src/Plugin/TestsiteBuilder/BaseEntityTables/Media.php
+++ b/src/Plugin/TestsiteBuilder/BaseEntityTables/Media.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\testsite_builder\Plugin\TestsiteBuilder\BaseEntityTables;
 
+use Drupal\testsite_builder\ContentCreatorStorage;
+
 /**
  * Media type plugin.
  *
@@ -16,19 +18,18 @@ class Media extends Generic {
   /**
    * {@inheritdoc}
    */
-  public function alterRowTemplate(array &$row_template, array $entity_state_info) {
-    $contentCreatorStorage = $entity_state_info['content_creator_storage'];
-
-    foreach (['media_field_data', 'media_field_revision'] as $table_name) {
-      if (isset($row_template[$table_name])) {
-        $thumbnail = $contentCreatorStorage->getSampleDataType('image');
-        $row_template[$table_name]['thumbnail__target_id'] = $thumbnail['target_id'];
-        $row_template[$table_name]['thumbnail__alt'] = $thumbnail['alt'];
-        $row_template[$table_name]['thumbnail__title'] = $thumbnail['title'];
-        $row_template[$table_name]['thumbnail__width'] = $thumbnail['width'];
-        $row_template[$table_name]['thumbnail__height'] = $thumbnail['height'];
-      }
+  public function alterRow(array &$row, $table_name, ContentCreatorStorage $content_creator_storage) {
+    if ($table_name != 'media_field_data' && $table_name != 'media_field_revision') {
+      return;
     }
+
+    $thumbnail = $content_creator_storage->getModSampleDataType('image', $row['mid']);
+
+    $row['thumbnail__target_id'] = $thumbnail['target_id'];
+    $row['thumbnail__alt'] = $thumbnail['alt'];
+    $row['thumbnail__title'] = $thumbnail['title'];
+    $row['thumbnail__width'] = $thumbnail['width'];
+    $row['thumbnail__height'] = $thumbnail['height'];
   }
 
 }


### PR DESCRIPTION
This PR contains the following changes:
1. New API is added for base entity tables plugin. It is an option to alter row before it's persisted in storage.
2. For media thumbnails, we are using this functionality and thumbnail images will be based on media ID.
3. A new function for fetching sample data is provided that takes the ID of an entity and provides sample data for it based on the modulo of existing sample data for that type.